### PR TITLE
fix: move speech props to hoc params

### DIFF
--- a/src/withSpeech/index.jsx
+++ b/src/withSpeech/index.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import _ from "lodash";
 
-const withSpeech = (Component) => {
+const withSpeech = (Component, { voiceName, speechTextPropName }) => {
   return class extends React.Component {
     constructor(props) {
       super(props);
@@ -11,8 +11,8 @@ const withSpeech = (Component) => {
       };
 
       this.componentRef = React.createRef();
-
       this.utterance = new SpeechSynthesisUtterance();
+
       speechSynthesis.addEventListener("voiceschanged", this.setSelectedVoice);
     }
 
@@ -21,7 +21,7 @@ const withSpeech = (Component) => {
 
       const selectedVoice = _.find(
         speechSynthesis.getVoices(),
-        (voice) => voice.voiceURI === this.props.voiceUri
+        (voice) => voice.name === voiceName
       );
 
       if (selectedVoice) {
@@ -36,7 +36,7 @@ const withSpeech = (Component) => {
 
       this.utterance.text = _.get(
         wrappedComponent.props,
-        `${_.get(this.props, "speechTextPropName")}`
+        `${speechTextPropName}`
       );
 
       this.utterance.voice = this.state.voice;
@@ -48,12 +48,7 @@ const withSpeech = (Component) => {
     };
 
     renderWrappedComponent = () => {
-      return (
-        <Component
-          {..._.omit(this.props, ["speechTextPropName", "voiceUri"])}
-          ref={this.componentRef}
-        />
-      );
+      return <Component {...this.props} ref={this.componentRef} />;
     };
 
     render() {

--- a/src/withSpeech/index.spec.jsx
+++ b/src/withSpeech/index.spec.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { mount } from "enzyme";
 import sinon from "sinon";
 import _ from "lodash";
-import index from "./index";
+import withSpeech from "./index";
 import MockWrappedComponent from "../mock/MockWrappedComponent";
 
 describe("withSpeech", () => {
@@ -27,7 +27,7 @@ describe("withSpeech", () => {
 
     const getVoicesStub = sinon
       .stub()
-      .callsFake(() => [{ voiceURI: "Karen" }, { voiceURI: "Alex" }]);
+      .callsFake(() => [{ voiceURI: "uri/Karen", name: 'Karen' }, { voiceURI: "uri/Alex", name: 'Alex' }]);
 
     global.speechSynthesis = {
       addEventListener: eventListenerStub,
@@ -36,7 +36,10 @@ describe("withSpeech", () => {
       cancel: sandbox.spy(),
     };
 
-    ComponentWithSpeech = index(MockWrappedComponent);
+    ComponentWithSpeech = withSpeech(MockWrappedComponent, {
+      voiceName: "Karen",
+      speechTextPropName: "label",
+    });
   });
 
   afterEach(() => {
@@ -48,8 +51,6 @@ describe("withSpeech", () => {
       <ComponentWithSpeech
         name="Component Name 1"
         label="This is some text"
-        speechTextPropName={"label"}
-        voiceUri={"Karen"}
       />
     );
 
@@ -62,8 +63,6 @@ describe("withSpeech", () => {
       <ComponentWithSpeech
         name="Component Name 1"
         label="This is some text"
-        speechTextPropName={"label"}
-        voiceUri={"Karen"}
       />
     );
 
@@ -79,8 +78,6 @@ describe("withSpeech", () => {
       <ComponentWithSpeech
         name="Component Name 1"
         label="This is some text"
-        speechTextPropName={"label"}
-        voiceUri={"Karen"}
       />
     );
 
@@ -95,7 +92,7 @@ describe("withSpeech", () => {
 
     expect(global.speechSynthesis.speak.calledOnce).to.equal(true);
     expect(global.speechSynthesis.speak.args[0]).to.eql([
-      { text: "This is some text", voice: { voiceURI: "Karen" } },
+      { text: "This is some text", voice: { voiceURI: "uri/Karen", name: 'Karen' } },
     ]);
   });
 
@@ -104,8 +101,6 @@ describe("withSpeech", () => {
       <ComponentWithSpeech
         name="Component Name 1"
         label="This is some text"
-        speechTextPropName={"label"}
-        voiceUri={"Karen"}
       />
     );
 


### PR DESCRIPTION
#### Background Context
Speech props are currently being passed to the wrapped component and hence need to be passed on each call.
This PR will move then to HOC params, when it is created so they have to be only called once for the enhanced component. 

Also, change the voice param to check against voiceName instead of Uri, as different browsers have different uri formats.

#### Fixes Issue
Fixes #17 