### PR TITLE
fix: broken speech in firefox

### DIFF
--- a/src/withSpeech/index.jsx
+++ b/src/withSpeech/index.jsx
@@ -6,17 +6,28 @@ const withSpeech = (Component, { voiceName, speechTextPropName }) => {
     constructor(props) {
       super(props);
 
-      this.state = {
-        voice: null,
-      };
-
       this.componentRef = React.createRef();
       this.utterance = new SpeechSynthesisUtterance();
 
-      speechSynthesis.addEventListener("voiceschanged", this.setSelectedVoice);
+      // Check if the voices are already loaded before the object construction
+      const voices = speechSynthesis.getVoices();
+
+      // Set the voice as the initial state.voice value as the `voiceschanged` event won't be triggered if voices are
+      // already loaded before the object construction
+      this.state = {
+        voice: voices.length
+          ? _.find(voices, (voice) => voice.name === voiceName)
+          : null,
+      };
+
+      // Add `voiceschanged` listener for scenarios when voices take long to load as they are loaded (async) by the browser
+      speechSynthesis.addEventListener(
+        "voiceschanged",
+        this.handleVoicesChanged
+      );
     }
 
-    setSelectedVoice = (event) => {
+    handleVoicesChanged = (event) => {
       event.preventDefault();
 
       const selectedVoice = _.find(

--- a/src/withSpeech/index.spec.jsx
+++ b/src/withSpeech/index.spec.jsx
@@ -21,13 +21,14 @@ describe("withSpeech", () => {
       voice: "",
     });
 
-    const eventListenerStub = sinon.stub().callsFake((event, listener) => {
+    const eventListenerStub = sandbox.stub().callsFake((event, listener) => {
       eventMap[event] = listener;
     });
 
-    const getVoicesStub = sinon
-      .stub()
-      .callsFake(() => [{ voiceURI: "uri/Karen", name: 'Karen' }, { voiceURI: "uri/Alex", name: 'Alex' }]);
+    const getVoicesStub = sandbox.stub().callsFake(() => [
+      { voiceURI: "uri/Karen", name: "Karen" },
+      { voiceURI: "uri/Alex", name: "Alex" },
+    ]);
 
     global.speechSynthesis = {
       addEventListener: eventListenerStub,
@@ -47,11 +48,11 @@ describe("withSpeech", () => {
   });
 
   it("should correctly render original wrapped component when voices are not loaded", () => {
+    const getVoicesStub = sandbox.stub().returns([]);
+    global.speechSynthesis.getVoices = getVoicesStub;
+
     const wrapper = mount(
-      <ComponentWithSpeech
-        name="Component Name 1"
-        label="This is some text"
-      />
+      <ComponentWithSpeech name="Component Name 1" label="This is some text" />
     );
 
     const wrapperComponentWrapper = wrapper.find(MockWrappedComponent);
@@ -60,10 +61,7 @@ describe("withSpeech", () => {
 
   it("should correctly render component with speech wrapper when voices are loaded", () => {
     const wrapper = mount(
-      <ComponentWithSpeech
-        name="Component Name 1"
-        label="This is some text"
-      />
+      <ComponentWithSpeech name="Component Name 1" label="This is some text" />
     );
 
     eventMap["voiceschanged"]({ preventDefault: _.noop });
@@ -75,10 +73,7 @@ describe("withSpeech", () => {
 
   it("should correctly trigger speech with correct utterance when click is simulated", () => {
     const wrapper = mount(
-      <ComponentWithSpeech
-        name="Component Name 1"
-        label="This is some text"
-      />
+      <ComponentWithSpeech name="Component Name 1" label="This is some text" />
     );
 
     eventMap["voiceschanged"]({ preventDefault: _.noop });
@@ -92,16 +87,16 @@ describe("withSpeech", () => {
 
     expect(global.speechSynthesis.speak.calledOnce).to.equal(true);
     expect(global.speechSynthesis.speak.args[0]).to.eql([
-      { text: "This is some text", voice: { voiceURI: "uri/Karen", name: 'Karen' } },
+      {
+        text: "This is some text",
+        voice: { voiceURI: "uri/Karen", name: "Karen" },
+      },
     ]);
   });
 
   it("should correctly trigger speech cancel when mouseLeave is simulated", () => {
     const wrapper = mount(
-      <ComponentWithSpeech
-        name="Component Name 1"
-        label="This is some text"
-      />
+      <ComponentWithSpeech name="Component Name 1" label="This is some text" />
     );
 
     eventMap["voiceschanged"]({ preventDefault: _.noop });


### PR DESCRIPTION
#### Background Context
The HOC impl isn't working in firefox in master

The issue was that the voices were loaded before the HOC was instance constructed. Hence the `voicesChanged` event wasn't fired unlike in chome where it always takes a while to load voices (loaded async).

#### Changes
Check for voices while the object is constructed and set the initial state.voice correctly.

#### Fixes Issue
#15 