### PR TITLE
chore: add custom input component

### DIFF
--- a/src/mock/CustomInput.jsx
+++ b/src/mock/CustomInput.jsx
@@ -1,0 +1,15 @@
+import React, { useState } from "react";
+import _ from "lodash";
+
+const CustomInput = ({ defaultValue, onValueChange }) => {
+  const [value, setValue] = useState(defaultValue);
+
+  const onChangeHandler = (event) => {
+    setValue(_.get(event, "target.value"));
+    onValueChange();
+  };
+
+  return <input value={value} onChange={onChangeHandler} />;
+};
+
+export default CustomInput;

--- a/src/mock/CustomInput.spec.jsx
+++ b/src/mock/CustomInput.spec.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { mount } from "enzyme";
+import sinon from "sinon";
+import CustomInput from "./CustomInput";
+
+describe("CustomInput", () => {
+  it("should correctly render custom input", () => {
+    const valueChangeSpy = sinon.spy();
+
+    const wrapper = mount(
+      <CustomInput
+        defaultValue={"This is awesome"}
+        onValueChange={valueChangeSpy}
+      />
+    );
+
+    const inputWrapper = wrapper.find("input");
+    expect(inputWrapper).to.have.lengthOf(1);
+    expect(inputWrapper.props().value).to.equal("This is awesome");
+  });
+
+  it("should correctly simulate change", () => {
+    const valueChangeSpy = sinon.spy();
+
+    const wrapper = mount(
+      <CustomInput
+        defaultValue={"This is awesome"}
+        onValueChange={valueChangeSpy}
+      />
+    );
+
+    let inputWrapper = wrapper.find("input");
+    expect(inputWrapper).to.have.lengthOf(1);
+    expect(inputWrapper.props().value).to.equal("This is awesome");
+
+    inputWrapper
+      .first()
+      .simulate("change", { target: { value: "New awesome value" } });
+
+    wrapper.update();
+
+    inputWrapper = wrapper.find("input");
+    expect(inputWrapper).to.have.lengthOf(1);
+    expect(inputWrapper.props().value).to.equal("New awesome value");
+    expect(valueChangeSpy.calledOnce).to.equal(true);
+  });
+});


### PR DESCRIPTION
- Custom Input React component for example to avoid unnecessary external package dependency.
- Add coverage

Issue:
Fixes #28 