### PR TITLE
feat: working example and refactor custom input

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "homepage": "https://github.com/adityasabnis/get-talking#readme",
   "dependencies": {
     "lodash": "^4.17.20",
+    "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   },

--- a/src/mock/CustomInput.jsx
+++ b/src/mock/CustomInput.jsx
@@ -1,15 +1,17 @@
-import React, { useState } from "react";
-import _ from "lodash";
+import React from "react";
+import PropTypes from "prop-types";
 
-const CustomInput = ({ defaultValue, onValueChange }) => {
-  const [value, setValue] = useState(defaultValue);
-
-  const onChangeHandler = (event) => {
-    setValue(_.get(event, "target.value"));
-    onValueChange();
+class CustomInput extends React.Component {
+  static propTypes = {
+    value: PropTypes.string.isRequired,
+    onValueChange: PropTypes.func.isRequired,
   };
 
-  return <input value={value} onChange={onChangeHandler} />;
-};
+  render() {
+    return (
+      <input value={this.props.value} onChange={this.props.onValueChange} />
+    );
+  }
+}
 
 export default CustomInput;

--- a/src/mock/CustomInput.spec.jsx
+++ b/src/mock/CustomInput.spec.jsx
@@ -8,10 +8,7 @@ describe("CustomInput", () => {
     const valueChangeSpy = sinon.spy();
 
     const wrapper = mount(
-      <CustomInput
-        defaultValue={"This is awesome"}
-        onValueChange={valueChangeSpy}
-      />
+      <CustomInput value={"This is awesome"} onValueChange={valueChangeSpy} />
     );
 
     const inputWrapper = wrapper.find("input");
@@ -23,10 +20,7 @@ describe("CustomInput", () => {
     const valueChangeSpy = sinon.spy();
 
     const wrapper = mount(
-      <CustomInput
-        defaultValue={"This is awesome"}
-        onValueChange={valueChangeSpy}
-      />
+      <CustomInput value={"This is awesome"} onValueChange={valueChangeSpy} />
     );
 
     let inputWrapper = wrapper.find("input");
@@ -41,7 +35,9 @@ describe("CustomInput", () => {
 
     inputWrapper = wrapper.find("input");
     expect(inputWrapper).to.have.lengthOf(1);
-    expect(inputWrapper.props().value).to.equal("New awesome value");
     expect(valueChangeSpy.calledOnce).to.equal(true);
+    expect(valueChangeSpy.args[0][0].target).to.eql({
+      value: "New awesome value",
+    });
   });
 });

--- a/www/App.jsx
+++ b/www/App.jsx
@@ -1,9 +1,28 @@
-import React from "react";
+import React, { useState } from "react";
+import _ from "lodash";
+import CustomInput from "../src/mock/CustomInput";
+import { withSpeech } from "../src";
 
-class App extends React.Component {
-  render() {
-    return <div>Example here</div>;
-  }
-}
+const CustomInputWithSpeech = withSpeech(CustomInput, {
+  voiceName: "Alex",
+  speechTextPropName: "value",
+});
+
+const App = () => {
+  const [alertInputText, setAlertInputText] = useState("My name is John Snow");
+
+  return (
+    <div>
+      <div>Click inside the component</div> <br />
+      <div>Custom Input</div>
+      <CustomInputWithSpeech
+        value={alertInputText}
+        onValueChange={({ target }) =>
+          setAlertInputText(_.get(target, "value"))
+        }
+      />
+    </div>
+  );
+};
 
 export default App;


### PR DESCRIPTION
Changes:
- Working example using CustomInput and withSpeech
- Refactor CustomInput to class component as withSpeech need to use ref which doesn't work with func component

Issue:
Fixes #29 

Screenshot:
![image](https://user-images.githubusercontent.com/73151902/97069763-21fd2400-161e-11eb-8904-55ab5683f31f.png)
