### PR TITLE
chore: remove path join duplication

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,11 +2,17 @@ const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CleanWebpackPlugin = require("clean-webpack-plugin");
 
+const settings = {
+  wwwPath: path.join(__dirname, "www"),
+  srcPath: path.join(__dirname, "src"),
+  distPath: path.join(__dirname, "dist"),
+};
+
 module.exports = (env, options) => {
   const isDevMode = options.mode === "development";
 
   return {
-    entry: [`${path.join(__dirname, "www")}/index.jsx`],
+    entry: [`${settings.wwwPath}/index.jsx`],
     devtool: isDevMode ? "source-map" : false,
     resolve: {
       extensions: [".jsx", ".js"],
@@ -15,10 +21,7 @@ module.exports = (env, options) => {
       rules: [
         {
           test: /\.(js|jsx)$/,
-          include: [
-            path.resolve(__dirname, "src"),
-            path.resolve(__dirname, "www"),
-          ],
+          include: [settings.srcPath, settings.wwwPath],
           exclude: /(node_modules|dist)/,
           use: {
             loader: "babel-loader",
@@ -27,12 +30,12 @@ module.exports = (env, options) => {
       ],
     },
     plugins: [
-      new CleanWebpackPlugin([path.resolve(__dirname, "dist")], {
+      new CleanWebpackPlugin([settings.distPath], {
         verbose: true,
       }),
       new HtmlWebpackPlugin({
         inject: true,
-        template: path.join(path.join(__dirname, "www"), "index.html"),
+        template: path.join(settings.wwwPath, "index.html"),
       }),
     ],
   };

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,11 +1,16 @@
 const path = require("path");
 
+const settings = {
+  srcPath: path.join(__dirname, "src"),
+  distPath: path.join(__dirname, "dist"),
+};
+
 module.exports = {
   module: {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        include: path.resolve(__dirname, "src"),
+        include: settings.srcPath,
         exclude: /(node_modules|dist)/,
         use: {
           loader: "babel-loader",
@@ -14,7 +19,7 @@ module.exports = {
     ],
   },
   output: {
-    path: path.resolve(__dirname, "dist"),
+    path: settings.distPath,
     filename: "index.js",
     libraryTarget: "commonjs2",
   },


### PR DESCRIPTION
##### Changes
Refactor webpack configs to remove path.join duplication
Change both dev and production configs

##### Issue:
Fixes #35 